### PR TITLE
include atomic

### DIFF
--- a/WLANOptimizer.cpp
+++ b/WLANOptimizer.cpp
@@ -29,6 +29,7 @@
 
 #include "WLANOptimizer.h"
 
+#include <atomic>
 #include <mutex>
 #include <chrono>
 using namespace std::chrono_literals;


### PR DESCRIPTION
i'm attempting to compile from visualstudio community edition on windows 10.

i was getting a lot of build errors and including `atomic` fixed a build error "identifier "Terminated" is undefined"

i'm not a windows developer, though. so i'm not sure if this was the right way to fix my build, but it works now 🤷‍♂️